### PR TITLE
fix: fail to open old files

### DIFF
--- a/lua/startup/init.lua
+++ b/lua/startup/init.lua
@@ -429,6 +429,7 @@ function startup.display()
                 directory_oldfiles = old_files
             else
                 old_files = utils.get_oldfiles(options.oldfiles_amount or 5)
+                directory_oldfiles = old_files
             end
             if options.fold_section then
                 section_alignments[vim.trim(options.title)] = options.align


### PR DESCRIPTION
when set `oldfiles_directory = false`, there is an error.
```lua
  body = {
    type = "oldfiles",
    oldfiles_directory = false,
    align = "center",
    fold_section = false,
    title = "Oldfiles",
    margin = 5,
    content = "",
    highlight = "String",
    default_color = "",
    oldfiles_amount = 5,
  },
```

![Cheese_Sat-15Jan22_13 51](https://user-images.githubusercontent.com/15076589/149611078-d810a8f9-47a1-41f6-a7d8-4f7173ced027.png)
