### PR TITLE
Fix Themes for Nerd Font 3.0.0 Release

### DIFF
--- a/lua/startup/themes/dashboard.lua
+++ b/lua/startup/themes/dashboard.lua
@@ -29,7 +29,7 @@ local settings = {
         margin = 5,
         content = {
             { " Find File", "Telescope find_files", "<leader>ff" },
-            { " Find Word", "Telescope live_grep", "<leader>lg" },
+            { "󰍉 Find Word", "Telescope live_grep", "<leader>lg" },
             { " Recent Files", "Telescope oldfiles", "<leader>of" },
             { " File Browser", "Telescope file_browser", "<leader>fb" },
             { " Colorschemes", "Telescope colorscheme", "<leader>cs" },

--- a/lua/startup/themes/dashboard.lua
+++ b/lua/startup/themes/dashboard.lua
@@ -29,7 +29,7 @@ local settings = {
         margin = 5,
         content = {
             { " Find File", "Telescope find_files", "<leader>ff" },
-            { "󰍉 Find Word", "Telescope live_grep", "<leader>lg" },
+            { " Find Word", "Telescope live_grep", "<leader>lg" },
             { " Recent Files", "Telescope oldfiles", "<leader>of" },
             { " File Browser", "Telescope file_browser", "<leader>fb" },
             { " Colorschemes", "Telescope colorscheme", "<leader>cs" },

--- a/lua/startup/themes/evil.lua
+++ b/lua/startup/themes/evil.lua
@@ -32,7 +32,7 @@ local settings = {
         margin = 5,
         content = {
             { " Find File", "Telescope find_files", "<leader>ff" },
-            { "󰍉 Find Word", "Telescope live_grep", "<leader>lg" },
+            { " Find Word", "Telescope live_grep", "<leader>lg" },
             { " Recent Files", "Telescope oldfiles", "<leader>of" },
             { " File Browser", "Telescope file_browser", "<leader>fb" },
             { " Colorschemes", "Telescope colorscheme", "<leader>cs" },

--- a/lua/startup/themes/evil.lua
+++ b/lua/startup/themes/evil.lua
@@ -32,7 +32,7 @@ local settings = {
         margin = 5,
         content = {
             { " Find File", "Telescope find_files", "<leader>ff" },
-            { " Find Word", "Telescope live_grep", "<leader>lg" },
+            { "󰍉 Find Word", "Telescope live_grep", "<leader>lg" },
             { " Recent Files", "Telescope oldfiles", "<leader>of" },
             { " File Browser", "Telescope file_browser", "<leader>fb" },
             { " Colorschemes", "Telescope colorscheme", "<leader>cs" },


### PR DESCRIPTION
Hello!

I've been noticing that icons for a few themes are not displaying properly since the Nerd Font updated to v3.0.0, and this pull request is simply just the modification for the icons.