### PR TITLE
Replaced removed nf-mdi-magnify icon with nf-md-magnify.

### DIFF
--- a/lua/startup/themes/dashboard.lua
+++ b/lua/startup/themes/dashboard.lua
@@ -29,7 +29,7 @@ local settings = {
         margin = 5,
         content = {
             { " Find File", "Telescope find_files", "<leader>ff" },
-            { " Find Word", "Telescope live_grep", "<leader>lg" },
+            { "󰍉 Find Word", "Telescope live_grep", "<leader>lg" },
             { " Recent Files", "Telescope oldfiles", "<leader>of" },
             { " File Browser", "Telescope file_browser", "<leader>fb" },
             { " Colorschemes", "Telescope colorscheme", "<leader>cs" },

--- a/lua/startup/themes/evil.lua
+++ b/lua/startup/themes/evil.lua
@@ -32,7 +32,7 @@ local settings = {
         margin = 5,
         content = {
             { " Find File", "Telescope find_files", "<leader>ff" },
-            { " Find Word", "Telescope live_grep", "<leader>lg" },
+            { "󰍉 Find Word", "Telescope live_grep", "<leader>lg" },
             { " Recent Files", "Telescope oldfiles", "<leader>of" },
             { " File Browser", "Telescope file_browser", "<leader>fb" },
             { " Colorschemes", "Telescope colorscheme", "<leader>cs" },


### PR DESCRIPTION
The material design icons in nerd fonts got relocated in [release V3.0.0 of nerdfonts](https://www.nerdfonts.com/releases). This broke the magnifying glass icon in the builtin themes. I replaced the old character codes with the new ones.