### PR TITLE
docs(readme): fix typos

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,8 +43,8 @@ require"startup".setup({
   options = {
       mapping_keys = true, -- display mapping (e.g. <leader>ff)
 
-      -- if < 0 fraction of screen width
-      -- if > 0 numbers of column
+      -- if < 1 fraction of screen width
+      -- if > 1 numbers of column
       cursor_column = 0.5,
 
       after = function() -- function that gets executed at the end
@@ -100,13 +100,13 @@ section = {
     -- "mapping" -> create mappings for commands that can be used
     -- use mappings.execute_command on the commands to execute
     -- "oldfiles" -> display oldfiles (can be opened with mappings.open_file/open_file_split)
-    type = "text", -- can be mappings or oldfiles
+    type = "text", -- can be mapping or oldfiles
     oldfiles_directory = false, -- if the oldfiles of the current directory should be displayed
     align = "center", -- "center", "left" or "right"
     fold_section = false, -- whether to fold or not
     title = "title", -- title for the folded section
-    -- if < 0 fraction of screen width
-    -- if > 0 numbers of column
+    -- if < 1 fraction of screen width
+    -- if > 1 numbers of column
     margin = 5, -- the margin for left or right alignment
     -- type of content depends on `type`
     -- "text" -> a table with string or a function that requires a function that returns a table of strings


### PR DESCRIPTION
Fix a few typos in the readme.

Fixes #49 