### PR TITLE
refactor: Refactor deprecated functions

### DIFF
--- a/lua/startup/init.lua
+++ b/lua/startup/init.lua
@@ -178,16 +178,16 @@ end
 
 -- Escapes magick caracters in a string such that we can use it as literals in a regex
 local escape = cache(
----@param s string
----@return string
+    ---@param s string
+    ---@return string
     function(s)
         return string.gsub(s, "([%^%$%(%)%.%[%]%*%+%-%?%%])", "%%%1")
     end
 )
 --- Gets the command corresponding to the passed line
 local get_cmd = cache(
----@param line string
----@return string?
+    ---@param line string
+    ---@return string?
     function(line)
         if old_cmd_syntax then
             for _, section in ipairs(sections_with_mappings) do
@@ -304,9 +304,9 @@ function startup.align(dict, alignment)
                 aligned,
                 utils.spaces(
                     vim.fn.winwidth(startup.window_id)
-                    - max_len
-                    - margin_calculated
-                    - 10
+                        - max_len
+                        - margin_calculated
+                        - 10
                 ) .. line
             )
         end
@@ -357,8 +357,8 @@ function startup.mapping_names(mappings)
             if settings.options.mapping_keys then
                 local space = utils.spaces(
                     length
-                    - #parse_mapping(mapping[3])
-                    - vim.fn.strdisplaywidth(mapping[1])
+                        - #parse_mapping(mapping[3])
+                        - vim.fn.strdisplaywidth(mapping[1])
                 )
                 table.insert(
                     mapnames,
@@ -426,11 +426,11 @@ function startup.display(force)
         if options.highlight == "" then
             vim.cmd(
                 "highlight Startup"
-                .. part
-                .. " guifg="
-                .. options.default_color
-                .. " guibg="
-                .. settings.colors.background
+                    .. part
+                    .. " guifg="
+                    .. options.default_color
+                    .. " guibg="
+                    .. settings.colors.background
             )
             options.highlight = "Startup" .. part
         end
@@ -531,7 +531,7 @@ function startup.display(force)
     if settings.folded_section_color ~= "" then
         vim.cmd(
             [[highlight StartupFoldedSection guifg=]]
-            .. settings.colors.folded_section
+                .. settings.colors.folded_section
         )
     end
     for _, line in ipairs(startup.lines) do

--- a/lua/startup/init.lua
+++ b/lua/startup/init.lua
@@ -19,7 +19,7 @@ local directory_oldfiles
 local get_cur_line = vim.api.nvim_get_current_line
 
 ---set option in buffer
-local set_buf_opt = vim.api.nvim_buf_set_option
+local set_opt = vim.api.nvim_set_option_value
 
 local section_alignments = {}
 local sections_with_mappings = {}
@@ -27,7 +27,7 @@ local sections_with_mappings = {}
 local startup_nvim_displayed
 local startup_nvim_loaded
 
-local current_section = ""
+-- local current_section = ""
 
 local old_cmd_syntax = false
 
@@ -70,7 +70,7 @@ end
 
 ---open fold under cursor
 function startup.open_section()
-    set_buf_opt(0, "modifiable", true)
+    set_opt("modifiable", true, { buf = 0 })
     local line_nr = vim.api.nvim_win_get_cursor(0)[1]
     local section_name = vim.trim(get_cur_line())
     local section_align = section_alignments[section_name]
@@ -111,7 +111,7 @@ function startup.open_section()
         0,
         { line_nr, math.floor(vim.fn.winwidth(startup.window_id) / 2) }
     )
-    set_buf_opt(0, "modifiable", false)
+    set_opt("modifiable", false, { buf = 0 })
     -- startup.redraw()
 end
 
@@ -178,16 +178,16 @@ end
 
 -- Escapes magick caracters in a string such that we can use it as literals in a regex
 local escape = cache(
-    ---@param s string
-    ---@return string
+---@param s string
+---@return string
     function(s)
         return string.gsub(s, "([%^%$%(%)%.%[%]%*%+%-%?%%])", "%%%1")
     end
 )
 --- Gets the command corresponding to the passed line
 local get_cmd = cache(
-    ---@param line string
-    ---@return string?
+---@param line string
+---@return string?
     function(line)
         if old_cmd_syntax then
             for _, section in ipairs(sections_with_mappings) do
@@ -246,8 +246,7 @@ function startup.open_file()
         end, directory_oldfiles)
         if vim.tbl_contains(trimmed_oldfiles, filename) then
             -- if vim.tbl_contains(function(element) return vim.trim(element) end ,directory_oldfiles), filename) then
-            local directory = vim.api.nvim_exec([[pwd]], true)
-            filename = directory .. filename
+            filename = vim.fs.joinpath(vim.fn.getcwd(), filename)
         end
     end
     if file_exists(filename) then
@@ -267,8 +266,7 @@ function startup.open_file_vsplit()
             return ele
         end, directory_oldfiles)
         if vim.tbl_contains(trimmed_oldfiles, filename) then
-            local directory = vim.api.nvim_exec([[pwd]], true)
-            filename = directory .. filename
+            filename = vim.fs.joinpath(vim.fn.getcwd(), filename)
         end
     end
     if file_exists(filename) then
@@ -283,10 +281,8 @@ end
 ---@return table aligned the aligned strings
 function startup.align(dict, alignment)
     local margin_calculated = 0
-    local margin = settings.margin and type(settings.margin) == "number" or 5
-    if margin == 0 then
-        margin_calculated = 0
-    elseif margin < 1 then
+    local margin = (type(settings.margin) == "number") and settings.margin or 5
+    if margin ~= 0 and margin < 1 then
         margin_calculated = vim.fn.winwidth(startup.window_id) * margin
     else
         margin_calculated = margin
@@ -308,9 +304,9 @@ function startup.align(dict, alignment)
                 aligned,
                 utils.spaces(
                     vim.fn.winwidth(startup.window_id)
-                        - max_len
-                        - margin_calculated
-                        - 10
+                    - max_len
+                    - margin_calculated
+                    - 10
                 ) .. line
             )
         end
@@ -361,8 +357,8 @@ function startup.mapping_names(mappings)
             if settings.options.mapping_keys then
                 local space = utils.spaces(
                     length
-                        - #parse_mapping(mapping[3])
-                        - vim.fn.strdisplaywidth(mapping[1])
+                    - #parse_mapping(mapping[3])
+                    - vim.fn.strdisplaywidth(mapping[1])
                 )
                 table.insert(
                     mapnames,
@@ -378,7 +374,7 @@ function startup.mapping_names(mappings)
     return mapnames
 end
 
-function startup.remove_buffer(info)
+function startup.remove_buffer()
     vim.defer_fn(function()
         if vim.fn.bufexists(startup.buffer_nr) ~= 0 then
             return
@@ -421,7 +417,7 @@ function startup.display(force)
     for _, part in ipairs(parts) do
         utils.empty(settings.options.paddings[padding_nr])
         padding_nr = padding_nr + 1
-        current_section = part
+        -- current_section = part
         local options = settings[part]
         options = utils.validate_settings(options)
         if type(options.content) == "function" then
@@ -430,11 +426,11 @@ function startup.display(force)
         if options.highlight == "" then
             vim.cmd(
                 "highlight Startup"
-                    .. part
-                    .. " guifg="
-                    .. options.default_color
-                    .. " guibg="
-                    .. settings.colors.background
+                .. part
+                .. " guifg="
+                .. options.default_color
+                .. " guibg="
+                .. settings.colors.background
             )
             options.highlight = "Startup" .. part
         end
@@ -535,7 +531,7 @@ function startup.display(force)
     if settings.folded_section_color ~= "" then
         vim.cmd(
             [[highlight StartupFoldedSection guifg=]]
-                .. settings.colors.folded_section
+            .. settings.colors.folded_section
         )
     end
     for _, line in ipairs(startup.lines) do
@@ -544,7 +540,7 @@ function startup.display(force)
             startup.align({ line[1] }, line[2])[1]
         )
     end
-    set_buf_opt(0, "modifiable", true)
+    set_opt("modifiable", true, { buf = 0 })
     vim.api.nvim_buf_set_lines(0, 0, -1, true, {})
     vim.api.nvim_buf_set_lines(0, 0, -1, false, startup.formatted_text)
     vim.cmd([[silent! %s/\s\+$//]]) -- clear trailing whitespace
@@ -554,7 +550,7 @@ function startup.display(force)
     if settings.options.after and settings.options.after ~= "" then
         settings.options.after()
     end
-    set_buf_opt(0, "modifiable", false)
+    set_opt("modifiable", false, { buf = 0 })
     vim.api.nvim_win_set_cursor(0, { 1, 1 })
     vim.cmd(
         [[autocmd CursorMoved * lua require"startup.utils".reposition_cursor()]]
@@ -637,14 +633,14 @@ function startup.redraw(other_file)
             startup.align({ line[1] }, line[2])[1]
         )
     end
-    set_buf_opt(0, "modifiable", true)
+    set_opt("modifiable", true, { buf = 0 })
     vim.api.nvim_buf_set_lines(0, 0, -1, true, {})
     vim.api.nvim_buf_set_lines(0, 0, -1, false, startup.formatted_text)
     vim.cmd([[silent! %s/\s\+$//]]) -- clear trailing whitespace
     for linenr, line in ipairs(startup.lines) do
         vim.api.nvim_buf_add_highlight(0, ns, line[4], linenr - 1, 0, -1)
     end
-    set_buf_opt(0, "modifiable", false)
+    set_opt("modifiable", false, { buf = 0 })
     if other_file then
         vim.fn.feedkeys("gg", "n")
         vim.api.nvim_win_set_cursor(startup.window_id, { 1, cursor[2] })

--- a/lua/startup/quotes.lua
+++ b/lua/startup/quotes.lua
@@ -92,7 +92,11 @@ local quotes = {
         "",
         "- Larry Wall",
     },
-    { "They did not know it was impossible, so they did it!", "", "- Mark Twain" },
+    {
+        "They did not know it was impossible, so they did it!",
+        "",
+        "- Mark Twain",
+    },
     {
         "If debugging is the process of removing bugs, then programming must be the process of putting them in.",
         "",

--- a/lua/startup/utils.lua
+++ b/lua/startup/utils.lua
@@ -4,12 +4,12 @@ local flag = false
 local new_cursor_pos
 local help_window
 
-local log = require("startup.log")
+-- local log = require("startup.log")
 
 local oldfiles_total = 0
 local all_oldfiles = {}
 
-local set_buf_opt = vim.api.nvim_buf_set_option
+local set_opt = vim.api.nvim_set_option_value
 
 local line_count = function()
     return vim.api.nvim_buf_line_count(0)
@@ -24,8 +24,8 @@ end
 
 function U.breaking_changes()
     local buf = vim.api.nvim_create_buf(false, true)
-    local ns = vim.api.nvim_create_namespace("Startup_breaking_changes")
-    vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
+    -- local ns = vim.api.nvim_create_namespace("Startup_breaking_changes")
+    set_opt("bufhidden", "wipe", { buf = buf })
     vim.api.nvim_buf_set_keymap(
         buf,
         "n",
@@ -81,9 +81,9 @@ function U.breaking_changes()
         style = "minimal",
     })
     -- vim.api.nvim_buf_add_highlight(buf, ns, "Special", 1, 0, -1)
-    vim.api.nvim_win_set_option(win, "winblend", 0)
-    vim.api.nvim_buf_set_option(buf, "modifiable", false)
-    vim.api.nvim_buf_set_option(buf, "filetype", "markdown")
+    set_opt("winblend", 0, { win = win })
+    set_opt("modifiable", false, { buf = buf })
+    set_opt("filetype", "markdown", { buf = buf })
 end
 
 ---load the theme specified
@@ -162,7 +162,7 @@ function U.key_help()
     local settings = require("startup").settings
     local buf = vim.api.nvim_create_buf(false, true)
     local user_mappings = require("startup").user_mappings
-    set_buf_opt(buf, "bufhidden", "wipe")
+    set_opt("bufhidden", "wipe", { buf = buf })
     local lines = {
         "    Startup.nvim Mappings    ",
         "",
@@ -191,10 +191,10 @@ function U.key_help()
             table.insert(
                 lines,
                 "    "
-                    .. lhs
-                    .. ":"
-                    .. U.spaces(length + 3 - #lhs)
-                    .. parse_mapping(rhs)
+                .. lhs
+                .. ":"
+                .. U.spaces(length + 3 - #lhs)
+                .. parse_mapping(rhs)
             )
         end
     end
@@ -219,13 +219,13 @@ function U.key_help()
             vim.api.nvim_buf_add_highlight(buf, ns, "Number", i, 1, length + 5)
         end
     end
-    vim.api.nvim_win_set_option(help_window, "winblend", 20)
+    set_opt("winblend", 20, { win = help_window })
     vim.api.nvim_buf_add_highlight(buf, ns, "Special", 0, 1, -1)
     for i = 2, 5, 1 do
         vim.api.nvim_buf_add_highlight(buf, ns, "String", i, 24, -1)
         vim.api.nvim_buf_add_highlight(buf, ns, "Number", i, 1, 23)
     end
-    set_buf_opt(buf, "modifiable", false)
+    set_opt("modifiable", false, { buf = buf })
     vim.cmd(
         [[autocmd CursorMoved * ++once lua require"startup.utils".close_help()]]
     )
@@ -304,7 +304,7 @@ function U.get_oldfiles_directory(amount)
     local home = vim.fn.expand("~")
     local oldfiles_raw = vim.fn.execute("oldfiles")
     local oldfiles_amount = 0
-    local directory = vim.api.nvim_exec([[pwd]], true)
+    local directory = vim.fn.getcwd()
     local oldfiles = {}
     for file in oldfiles_raw:gmatch(directory .. "[^\n]+") do
         if oldfiles_amount >= amount then
@@ -420,7 +420,7 @@ local function move_up()
             end
         end
     end
-    flag = false
+    -- flag = false
 end
 
 ---reposition cursor if cursor moved down
@@ -465,7 +465,7 @@ local function move_down()
             return
         end
     end
-    flag = false
+    -- flag = false
 end
 
 ---reposition cursor after it moved
@@ -506,27 +506,27 @@ end
 ---set all the options that should be set for the startup buffer
 function U.set_buf_options()
     local settings = require("startup").settings
-    local last_status = vim.api.nvim_get_option("laststatus")
-    local tab_line = vim.api.nvim_get_option("showtabline")
-    set_buf_opt(0, "bufhidden", "wipe")
-    set_buf_opt(0, "buftype", "nofile")
+    local last_status = vim.api.nvim_get_option_value("laststatus", {})
+    local tab_line = vim.api.nvim_get_option_value("showtabline", {})
+    set_opt("bufhidden", "wipe", { buf = 0 })
+    set_opt("buftype", "nofile", { buf = 0 })
     vim.cmd([[setlocal wrap]])
     if settings.options.disable_statuslines then
         vim.opt.laststatus = 0
         vim.opt.showtabline = 0
     end
-    set_buf_opt(0, "filetype", "startup")
-    set_buf_opt(0, "swapfile", false)
+    set_opt("filetype", "startup", { buf = 0 })
+    set_opt("swapfile", false, { buf = 0 })
     vim.cmd([[setlocal nonu nornu nolist]])
     vim.api.nvim_set_current_dir(
         vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ":h")
     )
     vim.cmd(
         [[autocmd BufEnter * lua if vim.opt.filetype~="startup" then vim.opt.laststatus=]]
-            .. last_status
-            .. [[;vim.opt.showtabline=]]
-            .. tab_line
-            .. [[ end]]
+        .. last_status
+        .. [[;vim.opt.showtabline=]]
+        .. tab_line
+        .. [[ end]]
     )
 end
 
@@ -587,7 +587,7 @@ function U.validate_settings(options)
                     and (
                         type(content) == "table"
                         or type(content)
-                            == "function"
+                        == "function"
                     )
                 then
                     return true

--- a/lua/startup/utils.lua
+++ b/lua/startup/utils.lua
@@ -166,16 +166,14 @@ function U.key_help()
     local lines = {
         "    Startup.nvim Mappings    ",
         "",
-        "    Execute command:    " .. parse_mapping(
-            settings.mappings.execute_command
-        ),
-        "    Open file:          " .. parse_mapping(settings.mappings.open_file),
-        "    Open file in split: " .. parse_mapping(
-            settings.mappings.open_file_split
-        ),
-        "    Open section:       " .. parse_mapping(
-            settings.mappings.open_section
-        ),
+        "    Execute command:    "
+            .. parse_mapping(settings.mappings.execute_command),
+        "    Open file:          "
+            .. parse_mapping(settings.mappings.open_file),
+        "    Open file in split: "
+            .. parse_mapping(settings.mappings.open_file_split),
+        "    Open section:       "
+            .. parse_mapping(settings.mappings.open_section),
     }
     local length
     if not vim.tbl_isempty(user_mappings) then
@@ -191,10 +189,10 @@ function U.key_help()
             table.insert(
                 lines,
                 "    "
-                .. lhs
-                .. ":"
-                .. U.spaces(length + 3 - #lhs)
-                .. parse_mapping(rhs)
+                    .. lhs
+                    .. ":"
+                    .. U.spaces(length + 3 - #lhs)
+                    .. parse_mapping(rhs)
             )
         end
     end
@@ -277,11 +275,8 @@ function U.get_oldfiles(amount)
                 .. "] "
                 .. string.gsub(file, home, "~")
         else
-            oldfiles_shortened[#oldfiles_shortened + 1] = string.gsub(
-                file,
-                home,
-                "~"
-            )
+            oldfiles_shortened[#oldfiles_shortened + 1] =
+                string.gsub(file, home, "~")
         end
         oldfiles_total = oldfiles_total + 1
     end
@@ -322,11 +317,8 @@ function U.get_oldfiles_directory(amount)
                 .. "] "
                 .. string.gsub(file, home, "~")
         else
-            oldfiles_shortened[#oldfiles_shortened + 1] = string.gsub(
-                file,
-                home,
-                "~"
-            )
+            oldfiles_shortened[#oldfiles_shortened + 1] =
+                string.gsub(file, home, "~")
         end
         oldfiles_total = oldfiles_total + 1
     end
@@ -523,10 +515,10 @@ function U.set_buf_options()
     )
     vim.cmd(
         [[autocmd BufEnter * lua if vim.opt.filetype~="startup" then vim.opt.laststatus=]]
-        .. last_status
-        .. [[;vim.opt.showtabline=]]
-        .. tab_line
-        .. [[ end]]
+            .. last_status
+            .. [[;vim.opt.showtabline=]]
+            .. tab_line
+            .. [[ end]]
     )
 end
 

--- a/lua/startup/utils.lua
+++ b/lua/startup/utils.lua
@@ -554,55 +554,37 @@ function U.validate_settings(options)
     if not options.oldfiles_amount then
         options.oldfiles_amount = 5
     end
-    vim.validate({
-        type = {
-            options.type,
-            function(arg)
-                for _, v in ipairs({ "mapping", "oldfiles", "text" }) do
-                    if v == arg then
-                        return true
-                    end
-                end
-                return false
-            end,
-            '"mapping" "text" or "oldfiles"',
-        },
-        align = {
-            options.align,
-            function(arg)
-                for _, v in ipairs({ "right", "left", "center" }) do
-                    if v == arg then
-                        return true
-                    end
-                end
-                return false
-            end,
-            '"center" "left" or "right"',
-        },
-        content = {
-            options.content,
-            function(content)
-                if
-                    options.type == "text"
-                    and (
-                        type(content) == "table"
-                        or type(content)
-                        == "function"
-                    )
-                then
-                    return true
-                elseif
-                    options.type == "mapping" and type(content) == "table"
-                then
-                    return true
-                elseif options.type == "oldfiles" then
-                    return true
-                end
-                return false
-            end,
-            "table for type=mapping and table or function for type=text",
-        },
-    })
+    vim.validate("type", options.type, function(arg)
+        for _, v in ipairs({ "mapping", "oldfiles", "text" }) do
+            if v == arg then
+                return true
+            end
+        end
+        return false
+    end, '"mapping" "text" or "oldfiles"')
+
+    vim.validate("align", options.align, function(arg)
+        for _, v in ipairs({ "right", "left", "center" }) do
+            if v == arg then
+                return true
+            end
+        end
+        return false
+    end, '"center" "left" or "right"')
+
+    vim.validate("content", options.content, function(content)
+        if
+            options.type == "text"
+            and (type(content) == "table" or type(content) == "function")
+        then
+            return true
+        elseif options.type == "mapping" and type(content) == "table" then
+            return true
+        elseif options.type == "oldfiles" then
+            return true
+        end
+        return false
+    end, "table for type=mapping and table or function for type=text")
     return options
 end
 


### PR DESCRIPTION
- Replaced `nvim_buf_set_option` and `nvim_win_set_option` -> `nvim_set_option_value`
- Replaced `vim.api.nvim_exec([[pwd]], true)` -> `vim.fn.getcwd()`
- Replaced `vim.api.nvim_get_option` -> `vim.api.nvim_get_option_value`
- Used newer syntax on `vim.validate`
- Commented out unused/unreachable code
- Ran `stylua .`
---
I tried to use extmark for highlights, but couldn't quite get it working
This branch seems to work on my computer, please do let me know if this needs to run more tests.
(P.S. I don't fully understand the gendocs.lua, so maybe I need some instructions on how to make the docs)