### PR TITLE
PR fix: skip startup.display() when nvim opens in pipeline

### DIFF
--- a/lua/startup/init.lua
+++ b/lua/startup/init.lua
@@ -600,7 +600,10 @@ function startup.setup(update)
     )
     if not vim.g.startup_disable_on_startup then
         vim.cmd(
-            [[autocmd VimEnter * lua if vim.fn.argc() == 0 then require("startup").display() end
+            [[autocmd VimEnter * lua for _, v in pairs(vim.v.argv) do if v == '-' then vim.g.read_from_stdin = 1 break end end]]
+        )
+        vim.cmd(
+            [[autocmd VimEnter * lua if vim.fn.argc() == 0 and vim.api.nvim_buf_get_name(0) == '' and vim.g.read_from_stdin == nil then require("startup").display() end
         autocmd BufRead * lua if vim.fn.argc() == 0 then require("startup").display() end]]
         )
         vim.cmd(

--- a/lua/startup/init.lua
+++ b/lua/startup/init.lua
@@ -563,11 +563,16 @@ function startup.display(force)
         autocmd BufLeave * lua require"startup".remove_buffer(vim.fn.getbufinfo()[1])
     ]])
     vim.defer_fn(function()
-        vim.api.nvim_win_set_cursor(0, {
-            2,
-            2,
-        })
-        startup.buffer_nr = vim.api.nvim_get_current_buf()
+        local buf_lines = vim.api.nvim_buf_get_lines(0, 0, 2, false)
+        if buf_lines[2] == nil then
+            return
+        else
+            startup.buffer_nr = vim.api.nvim_get_current_buf()
+            vim.api.nvim_win_set_cursor(0, {
+                2,
+                2,
+            })
+        end
     end, 1)
     if force then
         startup.buffer_nr = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
PR continues this issue: https://github.com/max397574/startup.nvim/issues/51

switching buffers works (:Startup display, then switch to last buffer. Buffer from pipeline or buffer from existed file, both ways), pipeline i. e. `echo "example" | nvim -` works (do not shows startup), open without args works (shows startup).